### PR TITLE
Fix accent typo in project structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ rota_aco/
 │       └── cli/           # interface de linha de comando (meta, dfs, acs)
 ├── graphml/               # grafos de entrada (.graphml)
 ├── tests/                 # testes unitários
-├── output/                # Saida dos PNG, Html e plots de convergência
+├── output/                # Saída dos PNG, Html e plots de convergência
 ├── requirements.txt
 └── README.md
 ```


### PR DESCRIPTION
## Summary
- correct `Saida` to `Saída` in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError for bus_network.graphml, ModuleNotFoundError for rota_aco)*

------
https://chatgpt.com/codex/tasks/task_e_683f4c7db024832ab4b844ca07eaa84e